### PR TITLE
add parametro notification_log_id no read notification

### DIFF
--- a/DitoSDK/ditosdk/src/main/java/br/com/dito/ditosdk/constant/Constants.java
+++ b/DitoSDK/ditosdk/src/main/java/br/com/dito/ditosdk/constant/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
         public static final String CHANNEL_TYPE_VALUE = "mobile";
         public static final String EVENT = "event";
         public static final String ID = "id";
+        public static final String NOTIFICATION_LOG_ID = "notification_log_id";
         public static final String USER_AGENT = "User-Agent";
         public static final String USER_AGENT_MOBILE = "Android";
     }

--- a/DitoSDK/ditosdk/src/main/java/br/com/dito/ditosdk/services/ReadNotification.java
+++ b/DitoSDK/ditosdk/src/main/java/br/com/dito/ditosdk/services/ReadNotification.java
@@ -35,7 +35,10 @@ public class ReadNotification extends BaseService {
                     json.addProperty(Constants.Headers.CHANNEL_TYPE, Constants.Headers.CHANNEL_TYPE_VALUE);
                     json.addProperty(Constants.Headers.TYPE, Constants.getParamNetworks());
                     json.addProperty(Constants.Headers.ID, Constants.getSocialId());
-//                    Log.e("DITO_SDK_READ_NOTIFICATION" , json.toString());
+                    if (jsonObject.has("notification") && !TextUtils.isEmpty(jsonObject.get("notification").getAsString())){
+                      String notificationLogId = jsonObject.get("notification_log_id").getAsString();
+                      json.addProperty(Constants.Headers.NOTIFICATION_LOG_ID, notificationLogId);
+                    }
                     NetworkUtil.requestPostMethod(Constants.getUrlReadNotification(identifier), json.toString(), callback);
                 }else{
                     Log.e("DITO_SDK", Constants.Mensagens.JSON_FORA_FORMATO);


### PR DESCRIPTION
Foi adicionado o parâmetro notification_log_id na requisição que manda o open notification. Esse parâmetro é essencial pra Dito saber de qual disparo foi a abertura.
