### PR TITLE
add reference

### DIFF
--- a/DitoSDK/samplekotlin/src/main/AndroidManifest.xml
+++ b/DitoSDK/samplekotlin/src/main/AndroidManifest.xml
@@ -10,18 +10,27 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".notificationActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="br.com.dito.samplekotlin.notificationActivity.OPEN" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 
-        <meta-data android:name="br.com.dito.API_KEY" android:value="MjAxNC0wNS0yMCAxMTowMzoyMSAtMDMwMEdyYXBoIEFwaSBWMjQ0"/>
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-        <meta-data android:name="br.com.dito.API_SECRET" android:value="HNVksCIUywbCIBJOv3UjgqmA7p5chPPFrpBbqvFW"/>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
+        <meta-data
+                android:name="br.com.dito.API_KEY"
+                android:value="MjAxNC0wNS0yMCAxMTowMzoyMSAtMDMwMEdyYXBoIEFwaSBWMjQ0" />
+        <meta-data
+                android:name="br.com.dito.API_SECRET"
+                android:value="HNVksCIUywbCIBJOv3UjgqmA7p5chPPFrpBbqvFW" />
 
         <service android:name="br.com.dito.ditosdk.notification.DitoMessagingService">
             <intent-filter>
@@ -29,8 +38,7 @@
             </intent-filter>
         </service>
 
-        <receiver android:name="br.com.dito.ditosdk.notification.NotificationOpenedReceiver"/>
-
+        <receiver android:name="br.com.dito.ditosdk.notification.NotificationOpenedReceiver" />
     </application>
 
 </manifest>

--- a/DitoSDK/samplekotlin/src/main/java/br/com/dito/samplekotlin/notificationActivity.kt
+++ b/DitoSDK/samplekotlin/src/main/java/br/com/dito/samplekotlin/notificationActivity.kt
@@ -1,0 +1,12 @@
+package br.com.dito.samplekotlin
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+
+class notificationActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_notification3)
+    }
+}

--- a/DitoSDK/samplekotlin/src/main/res/layout/activity_notification3.xml
+++ b/DitoSDK/samplekotlin/src/main/res/layout/activity_notification3.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".notificationActivity">
+
+    <TextView
+            android:id="@+id/textView"
+            android:layout_width="272dp"
+            android:layout_height="26dp"
+            android:text="activity opened when click in notification"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
@@ -17,7 +17,8 @@ object Dito  {
     private lateinit var apiSecret: String
     private lateinit var tracker: Tracker
 
-   const val  DITO_NOTIFICATION_ID = "br.com.dito.ditosdk.DITO_NOTIFICATION_ID"
+    const val DITO_NOTIFICATION_ID = "br.com.dito.ditosdk.DITO_NOTIFICATION_ID"
+    const val DITO_NOTIFICATION_REFERENCE = "br.com.dito.ditosdk.DITO_NOTIFICATION_REFERENCE"
 
     var options: Options? = null
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
@@ -78,8 +78,8 @@ object Dito  {
     /**
      * @param notification
      */
-    fun notificationRead(@NotNull notification: String) {
-        tracker.notificationRead(notification, RemoteService.notificationApi())
+    fun notificationRead(@NotNull notification: String, @Nullable reference: String) {
+        tracker.notificationRead(notification, RemoteService.notificationApi(), reference)
     }
 
     internal fun isInitialized(): Boolean {

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/Dito.kt
@@ -19,6 +19,7 @@ object Dito  {
 
     const val DITO_NOTIFICATION_ID = "br.com.dito.ditosdk.DITO_NOTIFICATION_ID"
     const val DITO_NOTIFICATION_REFERENCE = "br.com.dito.ditosdk.DITO_NOTIFICATION_REFERENCE"
+    const val DITO_DEEP_LINK = "br.com.dito.ditosdk.DITO_DEEP_LINK"
 
     var options: Options? = null
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -21,6 +21,7 @@ class DitoMessagingService: FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
         var notificationId: String = ""
         var reference: String = ""
+        var deepLink: String = ""
         val data = remoteMessage?.getData()?.getValue("data")
         val objData = JSONObject(data)
 
@@ -44,8 +45,12 @@ class DitoMessagingService: FirebaseMessagingService() {
 
         val message = objData.getJSONObject("details").get("message") as String
 
+        try {
+            deepLink = objData.getJSONObject("details").get("link") as String
+        } catch (e: Exception) {}
+
         if (reference != "" && notificationId != "") {
-            sendNotification(null, message, notificationId, reference)
+            sendNotification(null, message, notificationId, reference, deepLink)
         }
     }
 
@@ -59,11 +64,16 @@ class DitoMessagingService: FirebaseMessagingService() {
         }
     }
 
-    private fun sendNotification(title: String?, message: String?, notificationId: String, reference: String) {
+    private fun sendNotification(title: String?,
+                                 message: String?,
+                                 notificationId: String,
+                                 reference: String,
+                                 deepLink: String) {
         val intent = Intent(this, NotificationOpenedReceiver::class.java)
 
         intent.putExtra(Dito.DITO_NOTIFICATION_ID, notificationId)
         intent.putExtra(Dito.DITO_NOTIFICATION_REFERENCE, reference)
+        intent.putExtra(Dito.DITO_DEEP_LINK, deepLink)
 
         val pendingIntent = PendingIntent.getBroadcast(this, 7, intent, 0)
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -49,7 +49,7 @@ class DitoMessagingService: FirebaseMessagingService() {
             deepLink = objData.getJSONObject("details").get("link") as String
         } catch (e: Exception) {}
 
-        if (reference != "" && notificationId != "") {
+        if (notificationId != "") {
             sendNotification(null, message, notificationId, reference, deepLink)
         }
     }

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -79,7 +79,7 @@ class DitoMessagingService: FirebaseMessagingService() {
         intent.putExtra(Dito.DITO_NOTIFICATION_REFERENCE, reference)
         intent.putExtra(Dito.DITO_DEEP_LINK, deepLink)
 
-        val pendingIntent = PendingIntent.getBroadcast(this, 7, intent, 0)
+        val pendingIntent = PendingIntent.getBroadcast(this, 7, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
         val smallIcon = Dito.options?.iconNotification ?: applicationInfo.icon
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -34,11 +34,13 @@ class DitoMessagingService: FirebaseMessagingService() {
             }
         }
 
-        objData.get("reference")?.let {
-            if (it is String){
-                reference = it
+        try{
+            objData.get("reference")?.let {
+                if (it is String) {
+                    reference = it
+                }
             }
-        }
+        } catch (e: Exception) {}
 
         val message = objData.getJSONObject("details").get("message") as String
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -37,8 +37,6 @@ class DitoMessagingService: FirebaseMessagingService() {
         objData.get("reference")?.let {
             if (it is String){
                 reference = it
-            } else {
-                reference = ""
             }
         }
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -20,9 +20,10 @@ class DitoMessagingService: FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
 
         val notificationId = remoteMessage?.data?.get("notification")
+        val reference = remoteMessage?.data?.get("reference")
 
         remoteMessage?.notification?.let {
-            sendNotification(it.title, it.body, notificationId)
+            sendNotification(it.title, it.body, notificationId, reference)
         }
     }
 
@@ -36,11 +37,15 @@ class DitoMessagingService: FirebaseMessagingService() {
         }
     }
 
-    private fun sendNotification(title: String?, message: String?, notificationId: String?) {
+    private fun sendNotification(title: String?, message: String?, notificationId: String?, @Nullable reference: String) {
 
         val intent = Intent(this, NotificationOpenedReceiver::class.java)
         notificationId?.let {
             intent.putExtra(Dito.DITO_NOTIFICATION_ID, it)
+        }
+
+        reference?.let {
+            intent.putExtra(Dito.DITO_NOTIFICATION_REFERENCE, reference)
         }
 
         val pendingIntent = PendingIntent.getBroadcast(this, 7, intent, 0)

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/DitoMessagingService.kt
@@ -19,21 +19,22 @@ class DitoMessagingService: FirebaseMessagingService() {
 
     override fun onMessageReceived(remoteMessage: RemoteMessage?) {
         super.onMessageReceived(remoteMessage)
-        var notificationId: String = ""
-        var reference: String = ""
-        var deepLink: String = ""
+        var notificationId: String? = null
+        var reference: String? = null
+        var deepLink: String? = null
+        var message: String? = null
         val data = remoteMessage?.getData()?.getValue("data")
         val objData = JSONObject(data)
 
-        objData.get("notification")?.let {
-            if (it is String){
-                notificationId = it
-            } else if (it is Integer) {
-                notificationId = it.toString()
-            } else {
-                notificationId = ""
+        try{
+            objData.get("notification")?.let {
+                if (it is String){
+                    notificationId = it
+                } else if (it is Integer) {
+                    notificationId = it.toString()
+                }
             }
-        }
+        } catch (e: Exception) {}
 
         try{
             objData.get("reference")?.let {
@@ -43,15 +44,18 @@ class DitoMessagingService: FirebaseMessagingService() {
             }
         } catch (e: Exception) {}
 
-        val message = objData.getJSONObject("details").get("message") as String
+        try {
+            message = objData.getJSONObject("details").get("message") as String
+        } catch (e: Exception) {}
 
         try {
             deepLink = objData.getJSONObject("details").get("link") as String
         } catch (e: Exception) {}
 
-        if (notificationId != "") {
+        message?.let {
             sendNotification(null, message, notificationId, reference, deepLink)
         }
+
     }
 
     override fun onNewToken(token: String?) {
@@ -65,10 +69,10 @@ class DitoMessagingService: FirebaseMessagingService() {
     }
 
     private fun sendNotification(title: String?,
-                                 message: String?,
-                                 notificationId: String,
-                                 reference: String,
-                                 deepLink: String) {
+                                 message: String,
+                                 notificationId: String?,
+                                 reference: String?,
+                                 deepLink: String?) {
         val intent = Intent(this, NotificationOpenedReceiver::class.java)
 
         intent.putExtra(Dito.DITO_NOTIFICATION_ID, notificationId)

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -39,7 +39,7 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
         val packageName = context.packageName
         val intent = Dito.options?.contentIntent ?: context.packageManager?.
                 getLaunchIntentForPackage(packageName)
-        intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         return intent
     }
 }

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -9,6 +9,7 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         var notificationId: String = ""
         var reference: String = ""
+        var deepLink: String = ""
 
         context?.let {
             if (!Dito.isInitialized()) {
@@ -24,21 +25,29 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
             reference = it
         }
 
+        intent?.getStringExtra(Dito.DITO_DEEP_LINK)?.let {
+            deepLink = it
+        }
+
         if (reference != "" && notificationId != "") {
             Dito.notificationRead(notificationId, reference)
         }
 
         context?.let {
-            getIntent(it)?.let {
+            getIntent(it, deepLink)?.let {
                 context.startActivity(it)
             }
         }
     }
 
-    private fun getIntent(context: Context): Intent? {
+    private fun getIntent(context: Context, deepLink: String): Intent? {
         val packageName = context.packageName
-        val intent = Dito.options?.contentIntent ?: context.packageManager?.
-                getLaunchIntentForPackage(packageName)
+        var intent = Dito.options?.contentIntent ?: context.packageManager?.
+            getLaunchIntentForPackage(packageName)
+        if (deepLink != "") {
+            intent = Intent(deepLink)
+            intent.putExtra(Dito.DITO_DEEP_LINK, deepLink)
+        }
         intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         return intent
     }

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import br.com.dito.ditosdk.Dito
+import java.lang.Exception
 
 class NotificationOpenedReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
@@ -34,21 +35,24 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
         }
 
         context?.let {
-            getIntent(it, deepLink)?.let {
-                context.startActivity(it)
+            val (defaultIntent, deepLinkIntent) = getIntent(it, deepLink)
+            try {
+                context.startActivity(deepLinkIntent)
+            } catch (e: Exception)  {
+                context.startActivity(defaultIntent)
             }
         }
     }
 
-    private fun getIntent(context: Context, deepLink: String): Intent? {
+    private fun getIntent(context: Context, deepLink: String): Pair<Intent?, Intent?> {
         val packageName = context.packageName
         var intent = Dito.options?.contentIntent ?: context.packageManager?.
             getLaunchIntentForPackage(packageName)
+        var deepLinkIntent: Intent? = null
         if (deepLink != "") {
-            intent = Intent(deepLink)
-            intent.putExtra(Dito.DITO_DEEP_LINK, deepLink)
+            deepLinkIntent = Intent(deepLink)
         }
         intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
-        return intent
+        return Pair(intent, deepLinkIntent)
     }
 }

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -9,6 +9,8 @@ import br.com.dito.ditosdk.Dito
 class NotificationOpenedReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         Log.d("OpenedReceiver", "onReceive")
+        val notificationId = ""
+        val reference = ""
 
         context?.let {
             if (!Dito.isInitialized()) {
@@ -17,9 +19,16 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
         }
 
         intent?.getStringExtra(Dito.DITO_NOTIFICATION_ID)?.let {
-            Dito.notificationRead(it)
+            notificationId = it
         }
 
+        intent?.getStringExtra(Dito.DITO_NOTIFICATION_REFERENCE)?.let {
+            reference = it
+        }
+
+        if reference? && notificationId? {
+            Dito.notificationRead(notificationId, reference)
+        }
 
         context?.let {
             getIntent(it)?.let {

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -23,24 +23,21 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
         }
 
         context?.let {
-            val (defaultIntent, deepLinkIntent) = getIntent(it, deepLink)
+            val intent = getIntent(it, deepLink)
             try {
-                context.startActivity(deepLinkIntent)
-            } catch (e: Exception)  {
-                context.startActivity(defaultIntent)
-            }
+                context.startActivity(intent)
+            } catch (e: Exception)  {}
         }
     }
 
-    private fun getIntent(context: Context, deepLink: String?): Pair<Intent?, Intent?> {
+    private fun getIntent(context: Context, deepLink: String?): Intent? {
         val packageName = context.packageName
-        var intent = Dito.options?.contentIntent ?: context.packageManager?.
+        val intent = Dito.options?.contentIntent ?: context.packageManager?.
             getLaunchIntentForPackage(packageName)
-        var deepLinkIntent: Intent? = null
-        if (deepLink != null) {
-            deepLinkIntent = Intent(deepLink)
+        intent?.apply {
+            putExtra(Dito.DITO_DEEP_LINK, deepLink)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
-        return Pair(intent, deepLinkIntent)
+        return intent
     }
 }

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -8,9 +8,9 @@ import java.lang.Exception
 
 class NotificationOpenedReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        var notificationId: String = ""
-        var reference: String = ""
-        var deepLink: String = ""
+        var notificationId: String? = intent?.getStringExtra(Dito.DITO_NOTIFICATION_ID)
+        var reference: String? = intent?.getStringExtra(Dito.DITO_NOTIFICATION_REFERENCE)
+        var deepLink: String? = intent?.getStringExtra(Dito.DITO_DEEP_LINK)
 
         context?.let {
             if (!Dito.isInitialized()) {
@@ -18,19 +18,7 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
             }
         }
 
-        intent?.getStringExtra(Dito.DITO_NOTIFICATION_ID)?.let {
-            notificationId = it
-        }
-
-        intent?.getStringExtra(Dito.DITO_NOTIFICATION_REFERENCE)?.let {
-            reference = it
-        }
-
-        intent?.getStringExtra(Dito.DITO_DEEP_LINK)?.let {
-            deepLink = it
-        }
-
-        if (reference != "" && notificationId != "") {
+        if (reference != null && notificationId != null) {
             Dito.notificationRead(notificationId, reference)
         }
 
@@ -44,12 +32,12 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
         }
     }
 
-    private fun getIntent(context: Context, deepLink: String): Pair<Intent?, Intent?> {
+    private fun getIntent(context: Context, deepLink: String?): Pair<Intent?, Intent?> {
         val packageName = context.packageName
         var intent = Dito.options?.contentIntent ?: context.packageManager?.
             getLaunchIntentForPackage(packageName)
         var deepLinkIntent: Intent? = null
-        if (deepLink != "") {
+        if (deepLink != null) {
             deepLinkIntent = Intent(deepLink)
         }
         intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/notification/NotificationOpenedReceiver.kt
@@ -3,14 +3,12 @@ package br.com.dito.ditosdk.notification
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import br.com.dito.ditosdk.Dito
 
 class NotificationOpenedReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        Log.d("OpenedReceiver", "onReceive")
-        val notificationId = ""
-        val reference = ""
+        var notificationId: String = ""
+        var reference: String = ""
 
         context?.let {
             if (!Dito.isInitialized()) {
@@ -26,17 +24,16 @@ class NotificationOpenedReceiver: BroadcastReceiver() {
             reference = it
         }
 
-        if reference? && notificationId? {
+        if (reference != "" && notificationId != "") {
             Dito.notificationRead(notificationId, reference)
         }
 
         context?.let {
             getIntent(it)?.let {
-                context.startActivity(intent)
+                context.startActivity(it)
             }
         }
     }
-
 
     private fun getIntent(context: Context): Intent? {
         val packageName = context.packageName

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/tracking/Tracker.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/tracking/Tracker.kt
@@ -107,11 +107,11 @@ internal class Tracker(private var apiKey: String, apiSecret: String, private va
         }
     }
 
-    fun notificationRead(@NonNull notificationId: String, @NonNull api: NotificationApi) {
+    fun notificationRead(@NonNull notificationId: String, @NonNull api: NotificationApi, @Nullable notificationReference: String) {
         GlobalScope.launch(Dispatchers.IO) {
             val data = JsonObject()
-            data.addProperty("identifier", id)
-            data.addProperty("reference", reference)
+            data.addProperty("identifier", notificationReference.substring(5))
+            data.addProperty("reference", notificationReference)
 
             val params = NotificationOpenRequest(apiKey, apiSecret, data.toString())
 

--- a/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/tracking/Tracker.kt
+++ b/DitoSDK/sdk/src/main/java/br/com/dito/ditosdk/tracking/Tracker.kt
@@ -107,7 +107,7 @@ internal class Tracker(private var apiKey: String, apiSecret: String, private va
         }
     }
 
-    fun notificationRead(@NonNull notificationId: String, @NonNull api: NotificationApi, @Nullable notificationReference: String) {
+    fun notificationRead(@NonNull notificationId: String, @NonNull api: NotificationApi, notificationReference: String) {
         GlobalScope.launch(Dispatchers.IO) {
             val data = JsonObject()
             data.addProperty("identifier", notificationReference.substring(5))


### PR DESCRIPTION
## Reference
Será necessário enviar o reference do usuário no data do push para que a SDK Kotlin consiga enviar o evento de receive, mesmo que o usuário não esteja identificado no aparelho. Anteriormente, quando o usuário não estava identificado, o evento era salvo com o id fazio, e isso causava erro no momento de envio para a Dito. Com a alteração vigente, e uma alteração na SDK, ao receber o push o evento de receive é enviado, ou salvo, com o id presente no referece do push.